### PR TITLE
Fix parsing of ini files that end with comments

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20251211
 #
-# REGENDATA ("0.19.20250506",["github","ini.cabal"])
+# REGENDATA ("0.19.20251211",["github","ini.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -37,9 +40,9 @@ jobs:
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.2
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.2
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -110,8 +113,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -187,7 +190,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -212,7 +215,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_ini}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package ini" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package ini" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package ini" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(ini)$/; }' >> cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Fixed a parser bug where parsing would fail in presence of comments at the end of file.
+
 ## 0.5.0
 
 _2023-02-08, Chris Martin_

--- a/ini.cabal
+++ b/ini.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                ini
-version:             0.5.0
+version:             0.5.1
 synopsis:            Configuration files in the INI format.
 description:         Quick and easy configuration files in the INI format.
 license:             BSD3
@@ -15,7 +15,7 @@ build-type:          Simple
 
 tested-with:
   GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8

--- a/ini.cabal
+++ b/ini.cabal
@@ -54,9 +54,12 @@ test-suite ini-test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Main.hs
+  ghc-options:     -Wall
   build-depends:     base >= 4 && <5
+                   , QuickCheck
                    , ini
                    , hspec
+                   , text
                    , unordered-containers
 
   default-language:  Haskell98

--- a/src/Data/Ini.hs
+++ b/src/Data/Ini.hs
@@ -213,7 +213,7 @@ printIni = printIniWith defaultWriteIniSettings
 data KeySeparator
   = ColonKeySeparator
   | EqualsKeySeparator
-  deriving (Eq, Show)
+  deriving (Bounded, Enum, Eq, Show)
 
 -- | Settings determining how an INI file is written.
 data WriteIniSettings = WriteIniSettings
@@ -250,6 +250,7 @@ iniParser =
   (\kv secs -> Ini {iniSections = M.fromList secs, iniGlobals = kv}) <$>
   many keyValueParser <*>
   many sectionParser <*
+  skipComments <*
   (endOfInput <|> (fail . T.unpack =<< takeWhile (not . isControl)))
 
 -- | A section. Format: @[foo]@. Conventionally, @[FOO]@.
@@ -263,7 +264,6 @@ sectionParser =
      _ <- char ']'
      skipEndOfLine
      values <- many keyValueParser
-     skipComments
      return (T.strip name, values)
 
 -- | A key-value pair. Either @foo: bar@ or @foo=bar@.

--- a/src/Data/Ini.hs
+++ b/src/Data/Ini.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Clean configuration files in the INI format.
 --
@@ -234,8 +233,8 @@ writeIniFileWith wis fp = T.writeFile fp . printIniWith wis
 -- | Print an INI config.
 printIniWith :: WriteIniSettings -> Ini -> Text
 printIniWith wis i =
-  T.concat $ (map buildPair (iniGlobals i)) ++
-             (map buildSection (M.toList (iniSections i)))
+  T.concat $ map buildPair (iniGlobals i) ++
+             map buildSection (M.toList (iniSections i))
   where buildSection (name,pairs) =
           "[" <> name <> "]\n" <>
           T.concat (map buildPair pairs)
@@ -264,6 +263,7 @@ sectionParser =
      _ <- char ']'
      skipEndOfLine
      values <- many keyValueParser
+     skipComments
      return (T.strip name, values)
 
 -- | A key-value pair. Either @foo: bar@ or @foo=bar@.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-16.31
+resolver: lts-24.24
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,18 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Simple test suite.
 
 module Main where
 
+import           Data.Char (isControl, isSpace)
 import qualified Data.HashMap.Strict as HM
-import           Data.Ini
-import           Test.Hspec
+import           Data.Ini (Ini (..), KeySeparator (..), WriteIniSettings (..), parseIni, printIniWith)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Test.Hspec (describe, hspec, it, shouldBe)
+import           Test.QuickCheck
 
 main :: IO ()
 main =
     hspec $ do
-        describe "Regular files" $ do
-            it "Multi-section file with comments" $
+        describe "parseIni" $ do
+            it "parses multi-section file with comments" $
                 parseIni
                     "# Some comment.\n\
                     \[SERVER]\n\
@@ -44,7 +49,7 @@ main =
                             }
                         )
 
-            it "File with globals" $
+            it "parses file with globals" $
                 parseIni
                     "# Some comment.\n\
                     \port=6667\n\
@@ -72,13 +77,13 @@ main =
                             }
                         )
 
-            it "File with invalid keys" $
+            it "fails to parse file with invalid keys" $
                 parseIni
                     "Name=Foo\n\
                     \Name[en_GB]=Fubar"
                     `shouldBe` Left "Failed reading: Name[en_GB]=Fubar"
 
-            it "File ending with commented out sections" $
+            it "parses file ending with comments" $
                 parseIni
                     "[default]\n\
                     \a = 1\n\
@@ -91,3 +96,80 @@ main =
                             , iniGlobals = []
                             }
                         )
+
+            it "parses file with globals only" $
+                parseIni
+                    "global1 = hello\n\
+                    \global2 = 123\n\
+                    \# An end of file comment here"
+                    `shouldBe` Right
+                        ( Ini
+                            { iniSections = HM.empty
+                            , iniGlobals = [("global1", "hello"), ("global2", "123")]
+                            }
+                        )
+
+            it "parses empty file" $
+                parseIni "" `shouldBe` Right mempty
+
+            it "roundtrips with printIniWith" $
+                property $ \ini settings ->
+                    let printed = printIniWith settings ini
+                        parsed = parseIni printed
+                     in counterexample (T.unpack printed) $
+                            parsed === Right ini
+
+{- | Generate a non-empty text that is valid for use as a key
+Keys cannot contain delimiters (: =), brackets ([ ]), or control characters
+Keys also cannot start with comment markers (; #)
+-}
+genKey :: Gen Text
+genKey = do
+    firstChar <- arbitrary `suchThat` isValidFirstKeyChar
+    restChars <- listOf $ arbitrary `suchThat` isValidKeyChar
+    pure $ T.pack (firstChar : restChars)
+  where
+    isValidKeyChar c = not (c == '=' || c == ':' || c == '[' || c == ']' || isControl c || isSpace c)
+    isValidFirstKeyChar c = isValidKeyChar c && c /= ';' && c /= '#'
+
+-- | Generate text valid for use as a section name (no brackets)
+genSectionName :: Gen Text
+genSectionName = do
+    chars <- listOf1 $ arbitrary `suchThat` isValidSectionChar
+    let name = T.strip $ T.pack chars
+    if T.null name
+        then genSectionName -- retry if stripping results in empty
+        else pure name
+  where
+    isValidSectionChar c = c /= '[' && c /= ']' && not (isControl c)
+
+-- | Generate text valid for use as a value (no newlines)
+genValue :: Gen Text
+genValue = do
+    chars <- listOf $ arbitrary `suchThat` (not . isControl)
+    pure $ T.strip $ T.pack chars
+
+genKeyValue :: Gen (Text, Text)
+genKeyValue = (,) <$> genKey <*> genValue
+
+instance Arbitrary KeySeparator where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary Ini where
+    arbitrary = do
+        numSections <- choose (0, 2)
+        sections <- vectorOf numSections $ do
+            name <- genSectionName
+            numPairs <- choose (0, 2)
+            pairs <- vectorOf numPairs genKeyValue
+            pure (name, pairs)
+        numGlobals <- choose (0, 3)
+        globals <- vectorOf numGlobals genKeyValue
+        pure $
+            Ini
+                { iniSections = HM.fromList sections
+                , iniGlobals = globals
+                }
+
+instance Arbitrary WriteIniSettings where
+    arbitrary = WriteIniSettings <$> arbitrary

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -119,10 +119,6 @@ main =
                      in counterexample (T.unpack printed) $
                             parsed === Right ini
 
-{- | Generate a non-empty text that is valid for use as a key
-Keys cannot contain delimiters (: =), brackets ([ ]), or control characters
-Keys also cannot start with comment markers (; #)
--}
 genKey :: Gen Text
 genKey = do
     firstChar <- arbitrary `suchThat` isValidFirstKeyChar
@@ -132,7 +128,6 @@ genKey = do
     isValidKeyChar c = not (c == '=' || c == ':' || c == '[' || c == ']' || isControl c || isSpace c)
     isValidFirstKeyChar c = isValidKeyChar c && c /= ';' && c /= '#'
 
--- | Generate text valid for use as a section name (no brackets)
 genSectionName :: Gen Text
 genSectionName = do
     chars <- listOf1 $ arbitrary `suchThat` isValidSectionChar
@@ -143,7 +138,6 @@ genSectionName = do
   where
     isValidSectionChar c = c /= '[' && c /= ']' && not (isControl c)
 
--- | Generate text valid for use as a value (no newlines)
 genValue :: Gen Text
 genValue = do
     chars <- listOf $ arbitrary `suchThat` (not . isControl)
@@ -154,6 +148,8 @@ genKeyValue = (,) <$> genKey <*> genValue
 
 instance Arbitrary KeySeparator where
     arbitrary = arbitraryBoundedEnum
+    shrink ColonKeySeparator = []
+    shrink EqualsKeySeparator = [ColonKeySeparator]
 
 instance Arbitrary Ini where
     arbitrary = do
@@ -170,6 +166,26 @@ instance Arbitrary Ini where
                 { iniSections = HM.fromList sections
                 , iniGlobals = globals
                 }
+    shrink ini =
+        -- Shrink by removing sections
+        [ ini{iniSections = HM.fromList secs'}
+        | secs' <- shrinkList (const []) (HM.toList (iniSections ini))
+        ]
+            ++
+            -- Shrink by removing key-value pairs from sections
+            [ ini{iniSections = HM.fromList secs'}
+            | secs' <- shrinkOne shrinkSection (HM.toList (iniSections ini))
+            ]
+            ++
+            -- Shrink by removing globals
+            [ ini{iniGlobals = globals'}
+            | globals' <- shrinkList (const []) (iniGlobals ini)
+            ]
+      where
+        shrinkSection (name, pairs) = [(name, pairs') | pairs' <- shrinkList (const []) pairs]
+        shrinkOne _ [] = []
+        shrinkOne f (x : xs) = [x' : xs | x' <- f x] ++ [x : xs' | xs' <- shrinkOne f xs]
 
 instance Arbitrary WriteIniSettings where
     arbitrary = WriteIniSettings <$> arbitrary
+    shrink (WriteIniSettings sep) = WriteIniSettings <$> shrink sep

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,77 +10,84 @@ import           Test.Hspec
 
 main :: IO ()
 main =
-  hspec
-    (do describe
-          "Regular files"
-          (do it
-                "Multi-section file with comments"
-                (shouldBe
-                   (parseIni
-                      "# Some comment.\n\
-                      \[SERVER]\n\
-                      \port=6667\n\
-                      \hostname=localhost\n\
-                      \[AUTH]\n\
-                      \user=hello\n\
-                      \pass=world\n\
-                      \# Salt can be an empty string.\n\
-                      \salt=")
-                   (Right
-                      (Ini
-                         { iniSections =
-                             HM.fromList
-                               [ ( "AUTH"
-                                 , [ ("user", "hello")
-                                   , ("pass", "world")
-                                   , ("salt", "")
-                                   ])
-                               , ( "SERVER"
-                                 , [("port", "6667"), ("hostname", "localhost")])
-                               ]
-                         , iniGlobals = []
-                         })))
-              it
-                "File with globals"
-                (shouldBe
-                   (parseIni
-                      "# Some comment.\n\
-                      \port=6667\n\
-                      \hostname=localhost\n\
-                      \[AUTH]\n\
-                      \user=hello\n\
-                      \pass=world\n\
-                      \# Salt can be an empty string.\n\
-                      \salt=")
-                   (Right
-                      (Ini
-                         { iniSections =
-                             HM.fromList
-                               [ ( "AUTH"
-                                 , [ ("user", "hello")
-                                   , ("pass", "world")
-                                   , ("salt", "")
-                                   ])
-                               ]
-                         , iniGlobals =
-                             [("port", "6667"), ("hostname", "localhost")]
-                         })))
-              it
-                "File with invalid keys"
-                (shouldBe
-                   (parseIni
-                      "Name=Foo\n\
-                      \Name[en_GB]=Fubar")
-                   (Left "Failed reading: Name[en_GB]=Fubar"))
+    hspec $ do
+        describe "Regular files" $ do
+            it "Multi-section file with comments" $
+                parseIni
+                    "# Some comment.\n\
+                    \[SERVER]\n\
+                    \port=6667\n\
+                    \hostname=localhost\n\
+                    \[AUTH]\n\
+                    \user=hello\n\
+                    \pass=world\n\
+                    \# Salt can be an empty string.\n\
+                    \salt="
+                    `shouldBe` Right
+                        ( Ini
+                            { iniSections =
+                                HM.fromList
+                                    [
+                                        ( "AUTH"
+                                        ,
+                                            [ ("user", "hello")
+                                            , ("pass", "world")
+                                            , ("salt", "")
+                                            ]
+                                        )
+                                    ,
+                                        ( "SERVER"
+                                        , [("port", "6667"), ("hostname", "localhost")]
+                                        )
+                                    ]
+                            , iniGlobals = []
+                            }
+                        )
 
-              it "handles commented out sections" $
-                  parseIni
-                     "[default]\n\
-                     \a = 1\n\
-                     \\n\
-                     \#[staging-PI]\n\
-                     \#a = 3\n"
-                     `shouldBe` (Right (Ini
-                        { iniSections = HM.fromList [ ( "default", [ ("a", "1")])]
-                        , iniGlobals = []
-                        }))))
+            it "File with globals" $
+                parseIni
+                    "# Some comment.\n\
+                    \port=6667\n\
+                    \hostname=localhost\n\
+                    \[AUTH]\n\
+                    \user=hello\n\
+                    \pass=world\n\
+                    \# Salt can be an empty string.\n\
+                    \salt="
+                    `shouldBe` Right
+                        ( Ini
+                            { iniSections =
+                                HM.fromList
+                                    [
+                                        ( "AUTH"
+                                        ,
+                                            [ ("user", "hello")
+                                            , ("pass", "world")
+                                            , ("salt", "")
+                                            ]
+                                        )
+                                    ]
+                            , iniGlobals =
+                                [("port", "6667"), ("hostname", "localhost")]
+                            }
+                        )
+
+            it "File with invalid keys" $
+                parseIni
+                    "Name=Foo\n\
+                    \Name[en_GB]=Fubar"
+                    `shouldBe` Left "Failed reading: Name[en_GB]=Fubar"
+
+            it "File ending with commented out sections" $
+                parseIni
+                    "[default]\n\
+                    \a = 1\n\
+                    \\n\
+                    \#[staging-PI]\n\
+                    \#a = 2\n"
+                    `shouldBe` Right
+                        ( Ini
+                            { iniSections = HM.fromList [("default", [("a", "1")])]
+                            , iniGlobals = []
+                            }
+                        )

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -71,4 +71,16 @@ main =
                    (parseIni
                       "Name=Foo\n\
                       \Name[en_GB]=Fubar")
-                   (Left "Failed reading: Name[en_GB]=Fubar"))))
+                   (Left "Failed reading: Name[en_GB]=Fubar"))
+
+              it "handles commented out sections" $
+                  parseIni
+                     "[default]\n\
+                     \a = 1\n\
+                     \\n\
+                     \#[staging-PI]\n\
+                     \#a = 3\n"
+                     `shouldBe` (Right (Ini
+                        { iniSections = HM.fromList [ ( "default", [ ("a", "1")])]
+                        , iniGlobals = []
+                        }))))


### PR DESCRIPTION
Hello @andreasabel 

This library is used by amazonka, which uses it to parse config files (`.aws/config` and `.aws/credentials`) and if parsing of these fails, amazonka is not very informative about it, so it was hard to debug :sweat_smile: 

I was able to narrow the issue down to this library's inability to handle files that **end with** commented out lines.
~I'm adding reproducer for now, I might try to fix it later.~ EDIT the actual fix wasn't that hard, so pushed a fix as well.

Small example that fails to parse before the fix in this PR:
```ini
[default]
a = 1

#[staging-PI]
#a = 3
```